### PR TITLE
[DPM-1907] Suppress foreground crash error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:$_kotlinStdlib:$_kotlinVersion"
 
-    implementation 'net.gotev:uploadservice-okhttp:4.7.0'
+    implementation 'net.gotev:uploadservice-okhttp:4.9.2'
 
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
 }


### PR DESCRIPTION
## Objective \*

This is a temporary workaround. This simply suppress the android crash during background upload.

Steps to reproduce:
1. Initiate upload in background
2. Turn off wifi
3. Put the app in the foreground
4. Crash

Due to how this package is implemented, it violates the Android 12 Foreground task rule. This package is outdated and should be using workManage to launch uploads instead to avoid this error.

## Details and Context \*

This change simply updates the dependency to the latest

[> _Insert ticket link here._](https://sitemate.atlassian.net/browse/DPM-1907)

> _Insert Loom video link here if available._

## Pre-Submission Checklist \*

- [ ] I have reviewed all the changes one final time before opening this PR.

## Tests

- [ ] I have added automated tests for all new code introduced in this PR.
- [ ] I have not added automated tests, because... (explain below)

### Risks and uncertainty (optional)

- [ ] This PR doesn't introduce any new risks or uncertainties.
- [ ] This PR introduces new risks or uncertainties, because... (explain below)

## Additional Information

- Feedback Ladder Reminder

  - Mountain: Blocker & immediate action needed.
  - Boulder: Blocker & requires action
  - Pebble: Non-blocking, but requires future action (in either this or a future PR)
  - Sand: Non-blocking, but is generally best practice
  - Dust: Non-blocking comment

- [**Pull Request Standards**](https://sitemate.atlassian.net/wiki/spaces/ENG/pages/143458410/Branching+Pull+Requests+Code+Reviews#%E2%9C%A8--Pull-Requests)
